### PR TITLE
Error: You are trying to use "jade". jade is missing.

### DIFF
--- a/src/vue/package.json
+++ b/src/vue/package.json
@@ -20,6 +20,7 @@
     "vue": "vue/dist/vue.common.js"
   },
   "dependencies": {
+    "jade": "^1.11.0",
     "vee-validate": "^2.0.0-rc.3",
     "vue": "^2.0.1",
     "vue-head": "^2.0.11",


### PR DESCRIPTION
Adiciona jade 1.11.0 no src/vue/package.json para corrigir erro 'Error: You are trying to use jade. jade is missing.' quando se executa npm run watchify